### PR TITLE
Fix SonyLiv channels and remove old SL redirect components

### DIFF
--- a/internal/handlers/drm.go
+++ b/internal/handlers/drm.go
@@ -243,7 +243,7 @@ func MpdHandler(c *fiber.Ctx) error {
 			return []byte("<BaseURL>/render.dash/dash/</BaseURL>")
 		})
 	} else {
-		pattern := `<Period(.*)>`
+		pattern := `<Period(\s+[^>]*?)?\s*\/?>`
 		re = regexp.MustCompile(pattern)
 		resBody = re.ReplaceAllFunc(resBody, func(match []byte) []byte {
 			return []byte(fmt.Sprintf("%s\n<BaseURL>/render.dash/</BaseURL>", match))

--- a/pkg/television/types.go
+++ b/pkg/television/types.go
@@ -83,6 +83,7 @@ type LiveURLOutput struct {
 	StartTime   float64  `json:"startTime"`
 	VodStitch   bool     `json:"vodStitch"`
 	Mpd         MPD      `json:"mpd"`
+	IsDRM       bool     `json:"isDRM"`
 }
 
 // CategoryMap represents Categories for channels


### PR DESCRIPTION
- Fixed sonyLiv channels trowing error
- You must enable DRM for few SonyLiv channels as they only provide DASH streams.
- Removed old SL redirect channel components as their deprecated