### PR TITLE
Fix: Improve Shaka Player buffering for DRM streams

### DIFF
--- a/web/views/flow_player_drm.html
+++ b/web/views/flow_player_drm.html
@@ -64,7 +64,8 @@
             retryParameters: {
               maxAttempts: 3,
             },
-            // startAtSegmentBoundary: true,
+            startAtSegmentBoundary: true,
+            alwaysStreamFullSegments: true,
           },
         });
 


### PR DESCRIPTION
Set startAtSegmentBoundary and alwaysStreamFullSegments to true in the Shaka Player configuration for DRM streams.

This aims to resolve an issue where videos would buffer initially or after seeking, potentially due to playback starting or resuming at non-segment boundaries.