### PR TITLE
Fix: Prevent nil pointer dereference in OTP login flow

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -42,6 +42,7 @@ func Logout() error {
 // verifies the entered OTP by the user and logs in the user.
 // Returns any error encountered.
 func LoginOTP() error {
+	utils.Log = utils.GetLogger()
 	err := store.Init()
 	if err != nil {
 		return err
@@ -87,6 +88,7 @@ func LoginOTP() error {
 // and logs in the user if successful.
 // Returns any error encountered.
 func LoginPassword() error {
+	utils.Log = utils.GetLogger()
 	err := store.Init()
 	if err != nil {
 		return err


### PR DESCRIPTION
The panic occurred because the logger was used in `utils.GetDeviceID` before it was initialized. This happened when `store.Get("deviceId")` returned an error.

This commit fixes the issue by ensuring that the global logger `utils.Log` is initialized at the beginning of `cmd.LoginOTP` and `cmd.LoginPassword` functions before any code path that might use the logger is executed.

Fixes #501