### PR TITLE
Fix: Properly quote tvg-id in M3U entries using %q

### DIFF
--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -413,7 +413,7 @@ func ChannelsHandler(c *fiber.Ctx) error {
 			} else {
 				groupTitle = television.CategoryMap[channel.Category]
 			}
-			m3uContent += fmt.Sprintf("#EXTINF:-1 tvg-id=%s tvg-name=%q tvg-logo=%q tvg-language=%q tvg-type=%q group-title=%q, %s\n%s\n",
+			m3uContent += fmt.Sprintf("#EXTINF:-1 tvg-id=%q tvg-name=%q tvg-logo=%q tvg-language=%q tvg-type=%q group-title=%q, %s\n%s\n",
 				channel.ID, channel.Name, channelLogoURL, television.LanguageMap[channel.Language], television.CategoryMap[channel.Category], groupTitle, channel.Name, channelURL)
 		}
 


### PR DESCRIPTION
### Summary

Replaces `%s` with `%q` when formatting `tvg-id` in M3U output to ensure the attribute is properly quoted.

### What was the issue

- `tvg-id=channel123` was rendered without quotes
- Some IPTV players failed to match EPG data due to this

### Fix

- Changed string formatting from `%s` to `%q` to produce `tvg-id="channel123"`

### Testing

- Ran the server and generated `playlist.m3u`
- Verified correct `tvg-id="..."` format
- Confirmed proper EPG-channel linkage in IPTV player

![IMG20250710231348](https://github.com/user-attachments/assets/a087c2db-d940-46fd-939b-e835d42e53bc)
