### PR TITLE
feat: Enhance DRM handling and improve playback URL retrieval

### DIFF
--- a/internal/handlers/drm.go
+++ b/internal/handlers/drm.go
@@ -47,6 +47,16 @@ func getDrmMpd(channelID, quality string) (*DrmMpdOutput, error) {
 		return nil, err
 	}
 
+	// Quick fix for timesplay channels.
+	if liveResult.AlgoName == "timesplay" {
+		return &DrmMpdOutput{
+			PlayUrl:     tv_url,
+			LicenseUrl:  "/drm?auth=" + enc_key + "&channel_id=" + channelID + "&channel=" + channel_enc_url,
+			Tv_url_host: "",
+			Tv_url_path: "",
+		}, nil
+	}
+
 	parsedTvUrl, err := url.Parse(tv_url)
 	if err != nil {
 		utils.Log.Panicln(err)

--- a/pkg/television/television.go
+++ b/pkg/television/television.go
@@ -168,7 +168,7 @@ func (tv *Television) Live(channelID string) (*LiveURLOutput, error) {
 
 	var url string
 	if tv.AccessToken != "" {
-		url = "https://" + JIOTV_API_DOMAIN + "/playback/apis/v1/geturl?langId=6"
+		url = "https://" + JIOTV_API_DOMAIN + "/playback/apis/v1.1/geturl?langId=6"
 		req.Header.Set(headers.AccessToken, tv.AccessToken)
 	} else {
 		req.Header.Set("osVersion", "8.1.0")

--- a/pkg/television/types.go
+++ b/pkg/television/types.go
@@ -84,7 +84,7 @@ type LiveURLOutput struct {
 	VodStitch   bool     `json:"vodStitch"`
 	Mpd         MPD      `json:"mpd"`
 	IsDRM       bool     `json:"isDRM"`
-	ExtId       string   `json:"extId"`
+	ExtID       string   `json:"extId"`
 	AlgoName    string   `json:"algoName"`
 }
 

--- a/pkg/television/types.go
+++ b/pkg/television/types.go
@@ -84,6 +84,8 @@ type LiveURLOutput struct {
 	VodStitch   bool     `json:"vodStitch"`
 	Mpd         MPD      `json:"mpd"`
 	IsDRM       bool     `json:"isDRM"`
+	ExtId       string   `json:"extId"`
+	AlgoName    string   `json:"algoName"`
 }
 
 // CategoryMap represents Categories for channels

--- a/web/views/flow_player_drm.html
+++ b/web/views/flow_player_drm.html
@@ -64,8 +64,8 @@
             retryParameters: {
               maxAttempts: 3,
             },
-            startAtSegmentBoundary: true,
-            alwaysStreamFullSegments: true,
+            bufferingGoal: 5, // 5 seconds
+            lowLatencyMode: true,
           },
         });
 
@@ -81,8 +81,12 @@
             ) {
               const newUrl = new URL(request.uris[0]);
               // add query params host and path
-              newUrl.searchParams.append("host", "{{ .channel_host }}");
-              newUrl.searchParams.append("path", "{{ .channel_path }}");
+              const channelHost = "{{ .channel_host }}";
+              const channelPath = "{{ .channel_path }}";
+              if (channelHost !== "" && channelPath != "") {
+                newUrl.searchParams.append("host", channelHost);
+                newUrl.searchParams.append("path", channelPath);
+              }
               request.uris = [newUrl.toString()];
             }
           });

--- a/web/views/flow_player_drm.html
+++ b/web/views/flow_player_drm.html
@@ -82,7 +82,7 @@
               // add query params host and path
               const channelHost = "{{ .channel_host }}";
               const channelPath = "{{ .channel_path }}";
-              if (channelHost !== "" && channelPath != "") {
+              if (channelHost !== "" && channelPath !== "") {
                 newUrl.searchParams.append("host", channelHost);
                 newUrl.searchParams.append("path", channelPath);
               }

--- a/web/views/flow_player_drm.html
+++ b/web/views/flow_player_drm.html
@@ -65,7 +65,6 @@
               maxAttempts: 3,
             },
             bufferingGoal: 5, // 5 seconds
-            lowLatencyMode: true,
           },
         });
 


### PR DESCRIPTION
Closes #506 

- Added support for timesplay channels in getDrmMpd function.
- Updated API endpoint in Television's Live method for better URL retrieval.
- Extended LiveURLOutput struct to include extId and algoName fields.
- Improved flow_player_drm.html with buffering and low latency settings.