### PR TITLE
chore: update build scripts and Dockerfiles to use go 1.25 experiments

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -43,62 +43,11 @@ jobs:
           wget -q https://dl.google.com/android/repository/android-ndk-r26b-linux.zip
           unzip -qq android-ndk-r26b-linux.zip
           echo "$PWD/android-ndk-r26b/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
-  
+
       - name: Build Executables 🗄️ 🔃
         run: |
-          mkdir -p bin
-          allowed_archs="amd64 arm arm64 386"
-          for var in $(go tool dist list); do
-              # skip disallowed archs
-              if [[ ! $allowed_archs =~ "$(cut -d '/' -f 2 <<<$var)" ]]; then
-                  echo "Skipping: $var"
-                  continue
-              fi
-              # skip arm for windows
-              if [[ "$(cut -d '/' -f 1 <<<$var)" == "windows" && "$(cut -d '/' -f 2 <<<$var)" == "arm" ]]; then
-                  echo "Skipping: $var (windows/arm)"
-                  continue
-              fi
-              
-              file_name="jiotv_go-$(cut -d '/' -f 1 <<< $var)-$(cut -d '/' -f 2 <<< $var)"
-              case "$(cut -d '/' -f 1 <<< $var)" in
-                  "windows")
-                      echo "Building $var"
-                      CGO_ENABLED=0 GOOS="$(cut -d '/' -f 1 <<< $var)" GOARCH="$(cut -d '/' -f 2 <<< $var)" go build -o bin/"$file_name.exe" -trimpath -ldflags="-s -w" . &
-                      ;;
-                  "linux" | "darwin")
-                      echo "Building $var"
-                      CGO_ENABLED=0 GOOS="$(cut -d '/' -f 1 <<< $var)" GOARCH="$(cut -d '/' -f 2 <<< $var)" go build -o bin/"$file_name" -trimpath -ldflags="-s -w" . &
-                      ;;
-                  "android")
-                      echo "Building $var"
-                      case "$(cut -d '/' -f 2 <<<$var)" in
-                          "arm")
-                            CGO_ENABLED=1 GOOS="$(cut -d '/' -f 1 <<<$var)" GOARCH="$(cut -d '/' -f 2 <<<$var)" CC="armv7a-linux-androideabi28-clang" CXX="armv7a-linux-androideabi28-clang++" go build -o bin/"jiotv_go-$(cut -d '/' -f 1 <<<$var)-$(cut -d '/' -f 2 <<<$var)" -trimpath -ldflags="-s -w" .
-                          ;;
-                          "arm64")
-                            CGO_ENABLED=1 GOOS="$(cut -d '/' -f 1 <<<$var)" GOARCH="$(cut -d '/' -f 2 <<<$var)" CC="aarch64-linux-android32-clang" CXX="aarch64-linux-android32-clang++" go build -o bin/"jiotv_go-$(cut -d '/' -f 1 <<<$var)-$(cut -d '/' -f 2 <<<$var)" -trimpath -ldflags="-s -w" .
-                          ;;
-                          "amd64")
-                            CGO_ENABLED=1 GOOS="$(cut -d '/' -f 1 <<<$var)" GOARCH="$(cut -d '/' -f 2 <<<$var)" CC="x86_64-linux-android32-clang" CXX="x86_64-linux-android32-clang++" go build -o bin/"jiotv_go-$(cut -d '/' -f 1 <<<$var)-$(cut -d '/' -f 2 <<<$var)" -trimpath -ldflags="-s -w" .
-                          ;;
-                          *)
-                            echo "Skipping: $var"
-                          ;;
-                        esac
-                      ;;
-                  *)
-                      echo "Skipping: $var"
-                      ;;
-              esac
-          done
-          
-          # Wait for all background jobs to finish
-          wait
-
-          # Build for android5 arm with CC=armv7a-linux-androideabi21-clang
-          echo "Building android5 arm"
-          CGO_ENABLED=1 GOOS=android GOARCH=arm GOARM=7 CC="armv7a-linux-androideabi21-clang" CXX="armv7a-linux-androideabi21-clang++" go build -o bin/jiotv_go-android5-armv7 -trimpath -ldflags="-s -w" .
+          chmod +x ./scripts/build-binaries.sh
+          ./scripts/build-binaries.sh
 
       - name: Delete previous release 🗑️
         run: |
@@ -107,12 +56,14 @@ jobs:
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Generate tag
         id: gen_tag
         run: |
-          echo "tag=${{ github.ref_name }}.$(date +'%Y.%m.%d.%H.%M.%s')" >> $GITHUB_OUTPUT
+          echo "tag=${{ github.ref_name }}.$(date +'%Y.%m.%d.%H.%M')" >> $GITHUB_OUTPUT
+
       - name: Release 📦
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           draft: false
           prerelease: true
@@ -120,5 +71,4 @@ jobs:
           files: |
             ./bin/*
           generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM golang:1.25-alpine AS builder
 # Set the working directory inside the container
 WORKDIR /app
 
+# Enable Go 1.25 experiments for json v2 and the new GC during build
+ENV GOEXPERIMENT=jsonv2,greenteagc
+
 # Copy source files from the host computer to the container
 COPY go.mod ./
 COPY go.sum ./
@@ -14,7 +17,7 @@ COPY main.go ./main.go
 COPY VERSION ./VERSION
 
 # Build the Go app with optimizations
-RUN go build -ldflags="-s -w" -trimpath -o /app/jiotv_go .
+RUN go build -buildvcs=false -ldflags="-s -w" -trimpath -o /app/jiotv_go .
 
 # Stage 2: Create the final minimal image
 # skipcq: DOK-DL3007

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:1.25-alpine
 
 ENV GO111MODULE=on \
+    GOEXPERIMENT=jsonv2,greenteagc \
     JIOTV_DEBUG=true \
     JIOTV_PATH_PREFIX="/app/.jiotv_go"
 

--- a/scripts/build-binaries.sh
+++ b/scripts/build-binaries.sh
@@ -19,7 +19,7 @@ for var in $(go tool dist list); do
                 output_name+=".exe"
             fi
             echo "Building $var"
-            CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" go build -o "${output_name}" -trimpath -ldflags="-s -w" .
+            CGO_ENABLED=0 GOEXPERIMENT=jsonv2,greenteagc GOOS="$os" GOARCH="$arch" go build -buildvcs=false -o "${output_name}" -trimpath -ldflags="-s -w" .
         ;;
         "android")
             echo "Building $var"
@@ -43,7 +43,7 @@ for var in $(go tool dist list); do
                     continue
                     ;;
             esac
-            CGO_ENABLED=1 GOOS="$os" GOARCH="$arch" CC="$cc" CXX="$cxx" go build -o "bin/${file_name}" -trimpath -ldflags="-s -w" .
+            CGO_ENABLED=1 GOEXPERIMENT=jsonv2,greenteagc GOOS="$os" GOARCH="$arch" CC="$cc" CXX="$cxx" go build -buildvcs=false -o "bin/${file_name}" -trimpath -ldflags="-s -w" .
         ;;
         *)
             echo "Skipping: $var"
@@ -53,4 +53,4 @@ done
 
 # Build for android5 arm with CC=armv7a-linux-androideabi21-clang
 echo "Building android5 arm"
-CGO_ENABLED=1 GOOS=android GOARCH=arm GOARM=7 CC="armv7a-linux-androideabi21-clang" CXX="armv7a-linux-androideabi21-clang++" go build -o bin/jiotv_go-android5-armv7 -trimpath -ldflags="-s -w" .
+CGO_ENABLED=1 GOEXPERIMENT=jsonv2,greenteagc GOOS=android GOARCH=arm GOARM=7 CC="armv7a-linux-androideabi21-clang" CXX="armv7a-linux-androideabi21-clang++" go build -buildvcs=false -o bin/jiotv_go-android5-armv7 -trimpath -ldflags="-s -w" .


### PR DESCRIPTION
This pull request introduces several improvements to the build process, focusing on enabling Go 1.25 experimental features, standardizing build flags, and updating the release workflow for better maintainability and reproducibility. The changes are primarily centered around build scripts, Dockerfiles, and GitHub Actions workflows.

**Build process improvements:**

* Enabled Go 1.25 experimental features (`jsonv2` and `greenteagc`) in both `Dockerfile`, `dev.Dockerfile`, and all relevant build scripts and commands to take advantage of the latest Go optimizations. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R6-R8) [[2]](diffhunk://#diff-3ed65642ec1610de6b0f162c77dc8499662ebeb7057d3f6c89108952d1cb33deR4) [[3]](diffhunk://#diff-cbaf451fc3d91df0deb7944878b28d2f64a31bcef0c9ef679984c1ce0221dd3fL22-R22) [[4]](diffhunk://#diff-cbaf451fc3d91df0deb7944878b28d2f64a31bcef0c9ef679984c1ce0221dd3fL46-R46) [[5]](diffhunk://#diff-cbaf451fc3d91df0deb7944878b28d2f64a31bcef0c9ef679984c1ce0221dd3fL56-R56)
* Added the `-buildvcs=false` flag to all `go build` commands for more reproducible builds and to avoid embedding VCS information. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L17-R20) [[2]](diffhunk://#diff-cbaf451fc3d91df0deb7944878b28d2f64a31bcef0c9ef679984c1ce0221dd3fL22-R22) [[3]](diffhunk://#diff-cbaf451fc3d91df0deb7944878b28d2f64a31bcef0c9ef679984c1ce0221dd3fL46-R46) [[4]](diffhunk://#diff-cbaf451fc3d91df0deb7944878b28d2f64a31bcef0c9ef679984c1ce0221dd3fL56-R56)

**Workflow and automation updates:**

* Refactored the GitHub Actions pre-release workflow to delegate binary building to the new `scripts/build-binaries.sh` script, simplifying the workflow and centralizing build logic.
* Updated the release workflow to use `softprops/action-gh-release@v2`, improved tag generation (removed seconds from the timestamp), and fixed the release token configuration.