### PR TITLE
Add hdnea token handling in live stream URLs and related functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/madflojo/tasks v1.2.1
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v2 v2.27.7
-	golang.org/x/term v0.35.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -24,6 +23,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	golang.org/x/net v0.44.0 // indirect
+	golang.org/x/term v0.35.0 // indirect
 	golang.org/x/text v0.29.0 // indirect
 	olympos.io/encoding/edn v0.0.0-20201019073823-d3554ca0b0a3 // indirect
 )

--- a/internal/utils/handlers.go
+++ b/internal/utils/handlers.go
@@ -58,13 +58,13 @@ func DecryptURLParam(paramName, encryptedURL string) (string, error) {
 	if encryptedURL == "" {
 		return "", fmt.Errorf("%s not provided", paramName)
 	}
-	
+
 	decoded, err := secureurl.DecryptURL(encryptedURL)
 	if err != nil {
 		utils.SafeLogf("Error decrypting %s: %v", paramName, err)
 		return "", err
 	}
-	
+
 	return decoded, nil
 }
 
@@ -73,12 +73,14 @@ func ProxyRequest(c *fiber.Ctx, url string, client *fasthttp.Client, userAgent s
 	if userAgent != "" {
 		SetCommonHeaders(c, userAgent)
 	}
-	
+
 	if err := proxy.Do(c, url, client); err != nil {
 		return err
 	}
-	
+
 	c.Response().Header.Del(fiber.HeaderServer)
+	// Do not leak upstream cookies to the client
+	c.Response().Header.Del(fiber.HeaderSetCookie)
 	return nil
 }
 

--- a/pkg/television/types.go
+++ b/pkg/television/types.go
@@ -86,6 +86,7 @@ type LiveURLOutput struct {
 	IsDRM       bool     `json:"isDRM"`
 	ExtID       string   `json:"extId"`
 	AlgoName    string   `json:"algoName"`
+	Hdnea       string   `json:"-"` // parsed from URLs in Live response (hdnea query param); may rotate via Set-Cookie (__hdnea__) on m3u8/ts requests
 }
 
 // CategoryMap represents Categories for channels

--- a/pkg/television/url_utils.go
+++ b/pkg/television/url_utils.go
@@ -15,6 +15,7 @@ type EncryptedURLConfig struct {
 	ChannelID   string
 	EndpointURL string // The endpoint URL pattern (e.g., "/render.m3u8", "/render.ts")
 	Quality     string // Quality parameter for live streams
+	Hdnea       string // Akamai token value to be appended as query param hdnea
 }
 
 // CreateEncryptedURL creates an encrypted URL with auth parameters for various endpoints
@@ -36,6 +37,10 @@ func CreateEncryptedURL(config EncryptedURLConfig) ([]byte, error) {
 
 	if config.Quality != "" {
 		result += "&q=" + config.Quality
+	}
+
+	if config.Hdnea != "" {
+		result += "&hdnea=" + config.Hdnea
 	}
 
 	return []byte(result), nil


### PR DESCRIPTION
This pull request introduces comprehensive improvements to how Akamai token (`hdnea`) handling is managed throughout the live streaming and media serving pipeline. The changes ensure that the `hdnea` token is correctly extracted, propagated, and updated between upstream and downstream requests, and that it is never leaked to clients. This enhances stream reliability, especially when tokens rotate, and improves security by keeping cookies server-side only.

**Live stream and token propagation enhancements:**

* Added logic in `pkg/television/television.go` to extract the `hdnea` token from live stream URLs, append it to all relevant URLs if present, and include it in the `LiveURLOutput` struct for downstream use. [[1]](diffhunk://#diff-0f867743c99bf0c350cd630d60cd251673a4790131dbb427a48827a5ccca39b3R206-R260) [[2]](diffhunk://#diff-3e6ac2327b09a5f187ee85d511f306695972fbb4d8ec44a12f21a4773d5adde5R89)
* Updated handlers in `internal/handlers/handlers.go` to append `hdnea` as a query parameter to redirect URLs for live streams and quality selection, ensuring downstream endpoints receive the token. [[1]](diffhunk://#diff-0043929b176a6dd563ab4f5b393f095138a1200b3a22647ca5aa8e112579c80aL213-R233) [[2]](diffhunk://#diff-0043929b176a6dd563ab4f5b393f095138a1200b3a22647ca5aa8e112579c80aR276-R294)
* Modified the render, key, and TS handlers to parse `hdnea` from incoming queries and set it as a request cookie for upstream calls, without setting client cookies. Also, if upstream rotates the token, rewritten URLs and cookies are updated accordingly. [[1]](diffhunk://#diff-0043929b176a6dd563ab4f5b393f095138a1200b3a22647ca5aa8e112579c80aL291-R341) [[2]](diffhunk://#diff-0043929b176a6dd563ab4f5b393f095138a1200b3a22647ca5aa8e112579c80aR351-R369) [[3]](diffhunk://#diff-0043929b176a6dd563ab4f5b393f095138a1200b3a22647ca5aa8e112579c80aR439-R442) [[4]](diffhunk://#diff-0043929b176a6dd563ab4f5b393f095138a1200b3a22647ca5aa8e112579c80aR458-R466) [[5]](diffhunk://#diff-0043929b176a6dd563ab4f5b393f095138a1200b3a22647ca5aa8e112579c80aR486-R489)

**URL encryption and rewriting improvements:**

* Enhanced URL rewriting functions (`ReplaceM3U8`, `ReplaceTS`, `ReplaceAAC`, `ReplaceKey` in `pkg/television/television.go`) to extract `hdnea` from parameters and include it in the encrypted URL config, ensuring the token is always propagated when present. [[1]](diffhunk://#diff-0f867743c99bf0c350cd630d60cd251673a4790131dbb427a48827a5ccca39b3R532-R550) [[2]](diffhunk://#diff-0f867743c99bf0c350cd630d60cd251673a4790131dbb427a48827a5ccca39b3R565-R579) [[3]](diffhunk://#diff-0f867743c99bf0c350cd630d60cd251673a4790131dbb427a48827a5ccca39b3R594-R608) [[4]](diffhunk://#diff-0f867743c99bf0c350cd630d60cd251673a4790131dbb427a48827a5ccca39b3R619-R634)
* Updated `EncryptedURLConfig` and `CreateEncryptedURL` in `pkg/television/url_utils.go` to support the `Hdnea` field and append it as a query parameter when constructing URLs. [[1]](diffhunk://#diff-e8224778ad19f68d622043d0bcd872a1bf3547528c19b8e8066bd3118f7194f6R18) [[2]](diffhunk://#diff-e8224778ad19f68d622043d0bcd872a1bf3547528c19b8e8066bd3118f7194f6R42-R45)

**Security and cookie handling:**

* In the proxy handler (`internal/utils/handlers.go`), ensured that upstream cookies, especially `__hdnea__`, are not leaked to clients by removing `Set-Cookie` headers from responses.
* In the `Render` method of `Television`, ensured that if `hdnea` is present in the URL, it is sent as a cookie to upstream, and any new token received via `Set-Cookie` is captured and returned for further propagation. [[1]](diffhunk://#diff-0f867743c99bf0c350cd630d60cd251673a4790131dbb427a48827a5ccca39b3R272-R284) [[2]](diffhunk://#diff-0f867743c99bf0c350cd630d60cd251673a4790131dbb427a48827a5ccca39b3R294-R308)

**Dependency management:**

* Minor adjustment in `go.mod` to move `golang.org/x/term` from a direct to an indirect dependency. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L11) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R26)