### PR TITLE
fix: premium provider ID resolution and render-handler recovery hammering

### DIFF
--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -36,6 +36,14 @@ var (
 	EnableDRM         bool
 	renderHDNEACache  sync.Map
 	tokenRefreshGroup singleflight.Group
+	// renderChannelDeadCache marks a channel that just exhausted every quality
+	// candidate and still got a 404 - i.e. its manifest path genuinely doesn't
+	// exist right now, not a transient auth hiccup. A live player keeps
+	// polling /render.m3u8 every few seconds regardless, and without this each
+	// poll would independently re-run the full recovery dance (fetch a fresh
+	// live URL, retry, try every quality candidate), hammering Jio's live-URL
+	// API for a channel that isn't coming back within the cooldown window.
+	renderChannelDeadCache sync.Map
 )
 
 const (
@@ -45,11 +53,45 @@ const (
 	REQUEST_USER_AGENT    = headers.UserAgentOkHttp
 	hdneaCacheTTL         = 60 * time.Second // Aggressive TTL: 60 seconds (tokens expire ~90-120s, keep cache short)
 	hdneaRefreshLeadTime  = 20 * time.Second
+	// renderChannelDeadCacheTTL mirrors the JioTV Android app's own default
+	// cooldown for a channel that failed to come up (BroadcastUnicastModel's
+	// BTUS_RETRY_TIMER default, 60s) before it tries bootstrapping again.
+	renderChannelDeadCacheTTL = 60 * time.Second
 )
 
 type hdneaCacheEntry struct {
 	Token     string
 	UpdatedAt time.Time
+}
+
+func isChannelRecentlyDead(channelID string) bool {
+	if channelID == "" {
+		return false
+	}
+	fetchedAtRaw, ok := renderChannelDeadCache.Load(channelID)
+	if !ok {
+		return false
+	}
+	fetchedAt, ok := fetchedAtRaw.(time.Time)
+	if !ok || time.Since(fetchedAt) > renderChannelDeadCacheTTL {
+		renderChannelDeadCache.Delete(channelID)
+		return false
+	}
+	return true
+}
+
+func markChannelDead(channelID string) {
+	if channelID == "" {
+		return
+	}
+	renderChannelDeadCache.Store(channelID, time.Now())
+}
+
+func clearChannelDead(channelID string) {
+	if channelID == "" {
+		return
+	}
+	renderChannelDeadCache.Delete(channelID)
 }
 
 // truncateToken returns first 10 and last 10 chars of token for logging
@@ -716,7 +758,15 @@ func RenderHandler(c *fiber.Ctx) error {
 			utils.Log.Printf("[DEBUG] Auth failure or not found (Status %d) - fetching fresh live URL and auth", statusCode)
 		}
 
-		if channel_id != "" {
+		if statusCode == fiber.StatusNotFound && isChannelRecentlyDead(channel_id) {
+			// This channel's manifest just 404'd across every quality candidate
+			// within the last renderChannelDeadCacheTTL; skip re-running that
+			// same expensive recovery for this poll and let the fresh 404 above
+			// propagate as-is.
+			if os.Getenv("JIOTV_DEBUG") == "true" {
+				utils.Log.Printf("[DEBUG] RenderHandler - channel %s recently exhausted recovery, skipping", channel_id)
+			}
+		} else if channel_id != "" {
 			if refreshedLiveResult, refreshErr := refreshChannelToken(channel_id); refreshErr == nil && refreshedLiveResult != nil {
 				if freshToken := extractLiveResultHDNEA(refreshedLiveResult); freshToken != "" {
 					setCachedHDNEA(hdneaKey, freshToken)
@@ -770,6 +820,17 @@ func RenderHandler(c *fiber.Ctx) error {
 							break
 						}
 					}
+
+					// Every quality candidate still 404'd: this channel's manifest
+					// genuinely doesn't exist right now, so stop the next several
+					// polls from re-running this same recovery against Jio's API.
+					if statusCode == fiber.StatusNotFound {
+						markChannelDead(channel_id)
+					} else {
+						clearChannelDead(channel_id)
+					}
+				} else if statusCode == fiber.StatusOK {
+					clearChannelDead(channel_id)
 				}
 			}
 		}

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -246,6 +246,49 @@ func TestRenderHandler(t *testing.T) {
 	}
 }
 
+// TestRenderChannelDeadCache covers the negative cache that stops a live
+// player's repeated polling from re-running RenderHandler's full recovery
+// dance (fresh live URL + every quality candidate) against Jio's API once a
+// channel's manifest has already been confirmed missing.
+func TestRenderChannelDeadCache(t *testing.T) {
+	t.Run("unmarked channel is not recently dead", func(t *testing.T) {
+		id := "test-channel-unmarked"
+		defer clearChannelDead(id)
+		if isChannelRecentlyDead(id) {
+			t.Error("isChannelRecentlyDead() = true for a channel that was never marked")
+		}
+	})
+
+	t.Run("marked channel is recently dead until cleared", func(t *testing.T) {
+		id := "test-channel-marked"
+		defer clearChannelDead(id)
+		markChannelDead(id)
+		if !isChannelRecentlyDead(id) {
+			t.Error("isChannelRecentlyDead() = false immediately after markChannelDead()")
+		}
+		clearChannelDead(id)
+		if isChannelRecentlyDead(id) {
+			t.Error("isChannelRecentlyDead() = true after clearChannelDead()")
+		}
+	})
+
+	t.Run("expired mark is treated as not dead", func(t *testing.T) {
+		id := "test-channel-expired"
+		defer clearChannelDead(id)
+		renderChannelDeadCache.Store(id, time.Now().Add(-2*renderChannelDeadCacheTTL))
+		if isChannelRecentlyDead(id) {
+			t.Error("isChannelRecentlyDead() = true for a mark older than renderChannelDeadCacheTTL")
+		}
+	})
+
+	t.Run("empty channel ID is never dead", func(t *testing.T) {
+		markChannelDead("")
+		if isChannelRecentlyDead("") {
+			t.Error("isChannelRecentlyDead(\"\") = true; empty channel ID must never be cached")
+		}
+	})
+}
+
 func TestSLHandler(t *testing.T) {
 	type args struct {
 		c *fiber.Ctx

--- a/pkg/television/premium_providers_test.go
+++ b/pkg/television/premium_providers_test.go
@@ -260,3 +260,65 @@ func TestExtractPremiumProvidersFromAccessToken(t *testing.T) {
 		t.Fatalf("expected FanCode URL from token, got %s", premiumProviders[0].URL)
 	}
 }
+
+// TestPremiumProviderDisplayName covers resolveCatalogProviderID's directory
+// gate: premiumProviderDisplayName must find a display name for every
+// resolution path resolvePremiumProviderID supports, including keyword-only
+// entries with no static ProviderID (e.g. "jiocinema"). Before this was fixed
+// to defer to resolvePremiumProvider, such entries had no display name here,
+// so resolveCatalogProviderID never consulted the directory for them and sent
+// the raw identifier to the catalog/playback APIs instead of a real content
+// provider ID.
+func TestPremiumProviderDisplayName(t *testing.T) {
+	tests := []struct {
+		name               string
+		resolvedProviderID string
+		originalIdentifier string
+		wantDisplayName    string
+	}{
+		{"entitlement ID key", "Z0177", "Z0177", "FanCode"},
+		{"keyword match with a static ProviderID", "FANCODE", "fancode", "FanCode"},
+		{
+			name:               "keyword-only entry with no static ProviderID",
+			resolvedProviderID: "JIOCINEMA",
+			originalIdentifier: "jiocinema",
+			wantDisplayName:    "JioCinema Premium",
+		},
+		{"unknown identifier", "NOPE", "nope", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := premiumProviderDisplayName(tt.resolvedProviderID, tt.originalIdentifier); got != tt.wantDisplayName {
+				t.Errorf("premiumProviderDisplayName(%q, %q) = %q, want %q",
+					tt.resolvedProviderID, tt.originalIdentifier, got, tt.wantDisplayName)
+			}
+		})
+	}
+}
+
+// TestResolvePremiumProviderIDFallback covers the normalization contract
+// resolveCatalogProviderID relies on: an identifier matching no static entry
+// comes back as its own uppercased/trimmed form (so the directory can still
+// be tried against it), not empty - only a genuinely empty/whitespace
+// identifier should produce "".
+func TestResolvePremiumProviderIDFallback(t *testing.T) {
+	tests := []struct {
+		name       string
+		identifier string
+		want       string
+	}{
+		{"known static ID", "Z0177", "Z0177"},
+		{"unrecognized identifier falls back to normalized form", "  someProvider  ", "SOMEPROVIDER"},
+		{"empty identifier stays empty", "", ""},
+		{"whitespace-only identifier stays empty", "   ", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolvePremiumProviderID(tt.identifier); got != tt.want {
+				t.Errorf("resolvePremiumProviderID(%q) = %q, want %q", tt.identifier, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/television/television.go
+++ b/pkg/television/television.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/valyala/fasthttp"
 	"gopkg.in/yaml.v3"
@@ -740,18 +741,51 @@ func collectPlanProviders(planProviders []PlanProvider, premiumProviders *[]Prem
 // each provider's short name (lowercased, e.g. "fancode") to the content
 // provider ID used by the catalog API (e.g. "200169"). Requesting the document
 // without a providerId returns every provider.
+// providerDirectoryCacheTTL bounds how long the /cnf/provider directory is
+// reused before being re-fetched. The directory changes rarely, but every
+// premium catalog browse and playback request resolves through it, so
+// without a cache each one is an extra live round trip to Jio's servers.
+const providerDirectoryCacheTTL = 5 * time.Minute
+
+// providerDirectoryFetchTimeout bounds the /cnf/provider request itself.
+// fetchProviderDirectory now sits on the catalog/playback hot path (via
+// resolveCatalogProviderID), and the shared fasthttp.Client has no
+// ReadTimeout, so without this a slow/hung response would block those
+// requests indefinitely instead of falling back to the static provider ID.
+// 45s mirrors the app's own worst case for this endpoint: its
+// ProviderConfigNetworkModule OkHttpClient allows 15s to connect plus 30s to
+// read (fasthttp.DoTimeout is one combined deadline, so the two are summed).
+const providerDirectoryFetchTimeout = 45 * time.Second
+
+var (
+	providerDirectoryMu        sync.Mutex
+	providerDirectoryCache     map[string]string
+	providerDirectoryFetchedAt time.Time
+)
+
 func fetchProviderDirectory(client *fasthttp.Client, requestHeaders map[string]string) (map[string]string, error) {
-	requestConfig := utils.HTTPRequestConfig{
-		URL:     strings.TrimRight(PROVIDER_CONFIG_API_BASE_URL, "/") + "/cnf/provider",
-		Method:  "GET",
-		Headers: requestHeaders,
+	providerDirectoryMu.Lock()
+	if providerDirectoryCache != nil && time.Since(providerDirectoryFetchedAt) < providerDirectoryCacheTTL {
+		cached := providerDirectoryCache
+		providerDirectoryMu.Unlock()
+		return cached, nil
+	}
+	providerDirectoryMu.Unlock()
+
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	req.SetRequestURI(strings.TrimRight(PROVIDER_CONFIG_API_BASE_URL, "/") + "/cnf/provider")
+	req.Header.SetMethod("GET")
+	req.Header.SetUserAgent(headers.UserAgentOkHttp)
+	for key, value := range requestHeaders {
+		req.Header.Set(key, value)
 	}
 
-	resp, err := utils.MakeHTTPRequest(requestConfig, client)
-	if err != nil {
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+	if err := client.DoTimeout(req, resp, providerDirectoryFetchTimeout); err != nil {
 		return nil, err
 	}
-	defer fasthttp.ReleaseResponse(resp)
 
 	var directoryResponse PremiumProviderFilterResponse
 	if err := utils.ParseJSONResponse(resp, &directoryResponse); err != nil {
@@ -771,6 +805,11 @@ func fetchProviderDirectory(client *fasthttp.Client, requestHeaders map[string]s
 			providerDirectory[providerName] = providerID
 		}
 	}
+
+	providerDirectoryMu.Lock()
+	providerDirectoryCache = providerDirectory
+	providerDirectoryFetchedAt = time.Now()
+	providerDirectoryMu.Unlock()
 
 	return providerDirectory, nil
 }
@@ -1073,20 +1112,23 @@ func resolvePremiumProviderID(providerIdentifier string) string {
 		}
 	}
 
-	return ""
+	// No static entry matched; hand back the normalized identifier so callers
+	// can still try resolving it (e.g. against the live provider directory)
+	// without redoing this same normalization themselves.
+	return upperIdentifier
 }
 
 // premiumProviderDisplayName finds the display name backing a statically
 // registered provider entry, so its real content provider ID can be looked
-// up in the directory. It checks both the resolved provider ID and the
-// original identifier, since resolvePremiumProviderID can return an
-// unresolved entitlement ID (for example "Z0177") that is itself a key in
-// premiumProviderByID.
+// up in the directory. It defers to resolvePremiumProvider, which is the
+// single place that knows about all three provider tables (by ID, by plan
+// ID via the resolved ID, and by keyword via the original identifier) -
+// duplicating that lookup here previously left keyword-only entries such as
+// "jiocinema" (which has no static ProviderID) with no display name, so
+// resolveCatalogProviderID never consulted the directory for them and sent
+// the raw identifier to the catalog/playback APIs instead.
 func premiumProviderDisplayName(resolvedProviderID, originalIdentifier string) string {
-	if providerLink, exists := premiumProviderByID[strings.ToUpper(resolvedProviderID)]; exists {
-		return providerLink.DisplayName
-	}
-	if providerLink, exists := premiumProviderByPlanID[strings.ToUpper(strings.TrimSpace(originalIdentifier))]; exists {
+	if providerLink, exists := resolvePremiumProvider(resolvedProviderID, originalIdentifier); exists {
 		return providerLink.DisplayName
 	}
 	return ""
@@ -1102,9 +1144,6 @@ func premiumProviderDisplayName(resolvedProviderID, originalIdentifier string) s
 // a real content provider ID rather than an entitlement ID they reject.
 func resolveCatalogProviderID(client *fasthttp.Client, credentials *utils.JIOTV_CREDENTIALS, providerIdentifier string) string {
 	staticProviderID := resolvePremiumProviderID(providerIdentifier)
-	if staticProviderID == "" {
-		staticProviderID = strings.ToUpper(strings.TrimSpace(providerIdentifier))
-	}
 	if staticProviderID == "" {
 		return ""
 	}
@@ -1782,7 +1821,9 @@ func PremiumProviderPlayback(providerIdentifier string, playRequest PremiumProvi
 		return nil, errors.New("missing access token")
 	}
 
-	providerID := resolveCatalogProviderID(utils.GetRequestClient(), credentials, providerIdentifier)
+	tv := New(credentials)
+
+	providerID := resolveCatalogProviderID(tv.Client, credentials, providerIdentifier)
 	if providerID == "" {
 		return nil, errors.New("invalid provider identifier")
 	}
@@ -1813,7 +1854,6 @@ func PremiumProviderPlayback(providerIdentifier string, playRequest PremiumProvi
 		return nil, fmt.Errorf("unsupported streamType: %s", streamType)
 	}
 
-	tv := New(credentials)
 	formData := fasthttp.AcquireArgs()
 	defer fasthttp.ReleaseArgs(formData)
 


### PR DESCRIPTION
## Summary

Fixes a set of issues found during a code review of the premium-providers feature (#815) that had gone unaddressed since then.

- **`premiumProviderDisplayName` now defers to the existing `resolvePremiumProvider` helper** instead of duplicating its lookup. This fixes a real bug: any provider resolved only through `premiumProviderByKeyword` with no static `ProviderID` (e.g. the `"jiocinema"` entry) previously got no display name back, so `resolveCatalogProviderID` never consulted the live directory for it and sent the raw identifier straight to the catalog/playback APIs instead of a real content-provider ID.
- **`resolvePremiumProviderID` now returns the normalized identifier instead of `""`** when no static entry matches, removing a duplicate normalization step `resolveCatalogProviderID` no longer needs to redo itself.
- **`PremiumProviderPlayback` built two separate `fasthttp.Client` instances per call** (one via a bare `utils.GetRequestClient()` for ID resolution, another moments later inside `New(credentials)`); now builds one and reuses it.
- **`fetchProviderDirectory` (`/cnf/provider`) is now cached for 5 minutes and bounded by a 45s timeout.** It sits on the catalog/playback hot path via `resolveCatalogProviderID` and was previously fetched live, with no timeout, up to 3 times per single page view.
- **`RenderHandler`'s 404 recovery (fresh live URL + every quality candidate) now gets skipped for repeat polls** within 60s of a channel that just exhausted every candidate and still 404'd, instead of re-running that full recovery against Jio's API on every single poll from a live player. 60s mirrors the JioTV Android app's own default cooldown for a channel that fails to come up (`BroadcastUnicastModel.BTUS_RETRY_TIMER`, found by decompiling the current app).

## Why

The premium provider ID bug and the redundant directory fetch were both found while reviewing #815 after merge. The render-handler change came out of debugging [#823](https://github.com/JioTV-Go/jiotv_go/issues/823) — while confirming that a channel's dead stream was a Jio-side problem, I found a second channel (GOA 365) whose manifest 404s, and traced that every single player poll independently re-triggers the same expensive multi-candidate recovery against Jio's live-URL API with no memory of the last attempt.

## Verification

- `go build ./...` clean
- `go test ./pkg/television/... ./internal/handlers/...` passing, including new regression tests
- Full `go test ./...` shows the same 5 pre-existing environment-sensitive failures present on a clean `develop` checkout (Windows path/temp-file issues in `cmd`, `internal/config`, `pkg/epg`, `pkg/utils`) - none introduced by this change
- Added `TestPremiumProviderDisplayName` and `TestResolvePremiumProviderIDFallback`, and confirmed the first genuinely catches the original bug by reverting the fix and re-running (2 subtests failed, both pass with the fix restored)
- Added `TestRenderChannelDeadCache` covering the new negative-cache helpers (mark/clear/expiry/empty-ID)
- Live-tested against a real account: `/premium/providers/jiocinema/watch` and `/premium/providers/fancode/watch` both resolve correctly with no regression

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/television/... ./internal/handlers/...`
- [x] Full `go test ./...` (no new failures vs. clean `develop`)
- [x] Live-tested premium provider resolution against a real account